### PR TITLE
Add an ad hoc workaround for [SR-5986](https://bugs.swift.org/browse/SR-5986)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,23 @@
 
 import PackageDescription
 
+#if os(Linux)
+let linux = true
+#else 
+let linux = false
+#endif
+
+var targets: [Target] = [
+  // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+  // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+  .target(name:"CGIResponder", dependencies:[]),
+]
+if linux {
+  targets.append(.target(name:"SR_5986", dependencies:[], path:"Tests/SR-5986"))
+}
+targets.append(.testTarget(name:"CGIResponderTests", dependencies:linux ? ["CGIResponder", "SR_5986"] : ["CGIResponder"]))
+
+
 let package = Package(
   name:"CGIResponder",
   products:[
@@ -13,12 +30,7 @@ let package = Package(
     // Dependencies declare other packages that this package depends on.
     // .package(url: /* package url */, from: "1.0.0"),
   ],
-  targets:[
-    // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-    // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-    .target(name:"CGIResponder", dependencies:[]),
-    .testTarget(name:"CGIResponderTests", dependencies:["CGIResponder"]),
-  ],
+  targets:targets,
   swiftLanguageVersions:[4]
 )
 

--- a/Sources/CGIResponder/CFStringEncodings.swift
+++ b/Sources/CGIResponder/CFStringEncodings.swift
@@ -12,8 +12,6 @@
 import CoreFoundation
 import Foundation
 
-/// TODO: Workarounds are required for [SR-5986](https://bugs.swift.org/browse/SR-5986)
-
 extension CFString {
   public struct Encoding: RawRepresentable {
     public let rawValue: CFStringEncoding // aka UInt32

--- a/Tests/SR-5986/SR-5986.c
+++ b/Tests/SR-5986/SR-5986.c
@@ -1,0 +1,17 @@
+/***************************************************************************************************
+ SR-5986.c
+   © 2017 YOCKOW.
+     Licensed under MIT License.
+     See "LICENSE.txt" for more information.
+ **************************************************************************************************/
+
+/// Workaround for [SR-5986](https://bugs.swift.org/browse/SR-5986)
+
+#include "SR-5986.h"
+
+void * objc_retainAutoreleasedReturnValue(void *object) {
+  // I don't know whether this way is correct or not. It's just a workaround.
+  if (object) { swift_retain(object); }
+  return object;
+}
+

--- a/Tests/SR-5986/include/SR-5986.h
+++ b/Tests/SR-5986/include/SR-5986.h
@@ -1,0 +1,12 @@
+/***************************************************************************************************
+ SR-5986.h
+   © 2017 YOCKOW.
+     Licensed under MIT License.
+     See "LICENSE.txt" for more information.
+ **************************************************************************************************/
+
+/// Workaround for [SR-5986](https://bugs.swift.org/browse/SR-5986)
+
+void swift_retain(void *object); // Implemented in swift runtime.
+void * objc_retainAutoreleasedReturnValue(void *object); // Implemented in "SR-5986.c"
+


### PR DESCRIPTION
Now able to use `CFStringConvertEncodingToIANACharSetName(_:)` in `swift test` on Linux.