### PR TITLE
Add `travis_wait`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
 
 script:
   - ./build-install.rb --debug 
-  - ./build-install.rb --release --skip-test --install-prefix=/opt/SwiftCGIResponder
+  - travis_wait ./build-install.rb --release --skip-test --install-prefix=/opt/SwiftCGIResponder
   - ls -lA /opt/SwiftCGIResponder/lib
   - ls -lA /opt/SwiftCGIResponder/include
 


### PR DESCRIPTION
In Travis CI, processing speed on macOS is slow...
See [Build #118](https://travis-ci.org/YOCKOW/SwiftCGIResponder/builds/309813679).