### PR TITLE
Don't let `FormData` stop iterating when there is an empty value.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     // Dependencies declare other packages that this package depends on.
     .package(url:"https://github.com/YOCKOW/SwiftBonaFideCharacterSet.git", from: "1.6.2"),
     .package(url:"https://github.com/YOCKOW/SwiftNetworkGear.git", "0.14.4"..<"2.0.0"),
-    .package(url:"https://github.com/YOCKOW/SwiftTemporaryFile.git", from: "4.0.3"),
+    .package(url:"https://github.com/YOCKOW/SwiftTemporaryFile.git", from: "4.0.4"),
     .package(url:"https://github.com/YOCKOW/SwiftTimeSpecification.git", from: "3.3.0"),
     .package(url:"https://github.com/YOCKOW/SwiftXHTML.git", from: "2.2.3"),
     .package(url:"https://github.com/YOCKOW/ySwiftExtensions.git", from: "1.7.4"),

--- a/Sources/CGIResponder/FormData.swift
+++ b/Sources/CGIResponder/FormData.swift
@@ -278,7 +278,10 @@ public final class FormData: Sequence, IteratorProtocol {
       let value: FormData.Item.Value = try ({
         try temporaryFile.seek(toOffset: 0)
         if filename == nil {
-          guard let string = try temporaryFile.readToEnd().flatMap({ String(data: $0, encoding: stringEncoding) }) else {
+          guard let data = try temporaryFile.readToEnd() else {
+            return FormData.Item.Value(content: .string("", encoding: stringEncoding))
+          }
+          guard let string = String(data: data, encoding: stringEncoding) else {
             throw CGIResponderError.stringConversionFailure
           }
           return FormData.Item.Value(content: .string(string, encoding: stringEncoding))
@@ -288,7 +291,6 @@ public final class FormData: Sequence, IteratorProtocol {
                                      contentType: nilableContentType)
         }
       })()
-
       return FormData.Item(name: name, value: value)
     } catch {
       self.error = error

--- a/dependencies.svg
+++ b/dependencies.svg
@@ -77,7 +77,7 @@ a.external_repository_anchor {
 <title>TemporaryFile</title>
 <ellipse fill="none" stroke="black" cx="799.33" cy="-296.09" rx="69.09" ry="26.74" />
 <text text-anchor="middle" x="799.33" y="-299.89" font-family="monospace" font-size="12px"><a href="https://github.com/YOCKOW/SwiftTemporaryFile.git" xlink:href="https://github.com/YOCKOW/SwiftTemporaryFile.git" class="external_repository_anchor">TemporaryFile</a></text>
-<text text-anchor="middle" x="799.33" y="-284.89" font-family="monospace" font-size="12px">@4.0.3</text>
+<text text-anchor="middle" x="799.33" y="-284.89" font-family="monospace" font-size="12px">@4.0.4</text>
 </g>
 
 <g id="edge5" class="edge">


### PR DESCRIPTION
Resolves https://github.com/YOCKOW/SwiftCGIResponder/issues/71